### PR TITLE
Fix mobile scaling

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>About | Madaidan's Insecurities</title>
 </head>

--- a/android.html
+++ b/android.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Android | Madaidan's Insecurities</title>
 </head>

--- a/browser-tracking.html
+++ b/browser-tracking.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Browser Tracking | Madaidan's Insecurities</title>
 </head>

--- a/encrypted-dns.html
+++ b/encrypted-dns.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Encrypted DNS | Madaidan's Insecurities</title>
 </head>

--- a/firefox-chromium.html
+++ b/firefox-chromium.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Firefox and Chromium Security | Madaidan's Insecurities</title>
 </head>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Articles | Madaidan's Insecurities</title>
 </head>

--- a/linux-phones.html
+++ b/linux-phones.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Linux Phones | Madaidan's Insecurities</title>
 </head>

--- a/linux.html
+++ b/linux.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Linux | Madaidan's Insecurities</title>
 </head>

--- a/messengers.html
+++ b/messengers.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Messengers | Madaidan's Insecurities</title>
 </head>

--- a/openbsd.html
+++ b/openbsd.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>OpenBSD | Madaidan's Insecurities</title>
 </head>

--- a/security-privacy-advice.html
+++ b/security-privacy-advice.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>Security and Privacy Advice | Madaidan's Insecurities</title>
 </head>

--- a/styles.css
+++ b/styles.css
@@ -132,6 +132,7 @@ code {
     right: 20px;
     outline: none;
     font-size: 2rem;
+    background: transparent;
 }
 
 .p-final {
@@ -140,8 +141,16 @@ code {
 }
 
 @media screen and (max-width: 45em) {
+    body {
+        padding: 25px;
+    }
     body a {
         hyphens: auto;
+    }
+    h1 {
+        margin-left: 0;
+        margin-top: 0;
+        max-width: 75%;
     }
     code {
         word-break: break-all;

--- a/vpns.html
+++ b/vpns.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="styles.css">
   <title>VPNs | Madaidan's Insecurities</title>
 </head>


### PR DESCRIPTION
Hey @madaidan! I noticed that your site is lacking the `<meta name="viewport" content="width=device-width, initial-scale=1.0">` tag in its head, and isn't scaling super well on mobile. The text is too small. You can see this [here](https://user-images.githubusercontent.com/66244111/97103801-3e807700-1685-11eb-86a7-c0ae50675ef6.png) and [here](https://user-images.githubusercontent.com/66244111/97103871-ba7abf00-1685-11eb-83b9-d197d5c9ebd7.png). With the viewport scaling, it [looks correct](https://user-images.githubusercontent.com/66244111/97103752-d467d200-1684-11eb-8864-06d063101103.png). The toggle button would occasionally overlap with the title text, so I added some padding and margins. Hope this helps.

Also, someone created a clone of your site: https://madaidans-privacy.github.io

Love the site. Keep up the excellent work.