### PR TITLE
'Company' replaced by 'Organization' in firefox-chromium

### DIFF
--- a/firefox-chromium.html
+++ b/firefox-chromium.html
@@ -17,7 +17,7 @@
   <p class="date"><em><time datetime="2021-06-18">Last edited: June 18th, 2021</time></em></p>
 
   <p>
-    Firefox is sometimes recommended as a supposedly more secure browser because of its parent company's privacy practices.
+    Firefox is sometimes recommended as a supposedly more secure browser because of its parent organization's privacy practices.
     This article explains why this notion is not true and enumerates a number of security weaknesses in Firefox's security model
     when compared to Chromium. In particular, it covers the less granular process model, weaker sandboxing and lack of modern
     exploit mitigations. It is important to decouple privacy from security — this article does not attempt to compare the


### PR DESCRIPTION
'comapny' repaced by 'organization', as Mozilla is non-profit. In the first line

Before - Firefox is sometimes recommended as a supposedly more secure browser because of its parent company's privacy practices.
After - Firefox is sometimes recommended as a supposedly more secure browser because of its parent organization's privacy practices.