### PR TITLE
Blacklist ksmbd (SMB3 Kernel Server) in linux-hardening guide

### DIFF
--- a/guides/linux-hardening.html
+++ b/guides/linux-hardening.html
@@ -707,6 +707,7 @@ install udf /bin/false</code></pre>
 install nfs /bin/true
 install nfsv3 /bin/true
 install nfsv4 /bin/true
+install ksmbd /bin/true
 install gfs2 /bin/true</code></pre>
 
     <p>


### PR DESCRIPTION
There have already been vulnerabilities in the rc1-kernel:
https://www.phoronix.com/scan.php?page=news_item&px=SMB3-File-Server-Security-Fix