### PR TITLE
Advise for Pixel model now >=4a

### DIFF
--- a/security-privacy-advice.html
+++ b/security-privacy-advice.html
@@ -64,7 +64,7 @@
     modern exploit mitigations and more from the start. As such, they are far more locked down than other platforms and significantly
     more resistant to attacks. <br>
     <br>
-    Use either the stock operating system or preferably, <a href="https://grapheneos.org/">GrapheneOS</a> on a Pixel >=3. Do not
+    Use either the stock operating system or preferably, <a href="https://grapheneos.org/">GrapheneOS</a> on a Pixel >=4a. Do not
     root your device, do not keep your bootloader unlocked and stay away from alternative operating systems like LineageOS as
     they substantially worsen the security model. Read the <a href="android.html">Android article</a> for more details. <br>
     <br>


### PR DESCRIPTION
The GrapheneOS Website currently lists the 4a as the latest recommended device, therefore I propose this change.