### PR TITLE
Update Google Pixel Minimum Model

### DIFF
--- a/android.html
+++ b/android.html
@@ -153,7 +153,7 @@
   <h2 id="conclusion"><a href="#conclusion">Conclusion</a></h2>
 
   <p>
-    The best option for privacy and security on Android is to get a Pixel 4 or greater and flash <a href="https://grapheneos.org/">
+    The best option for privacy and security on Android is to get a Pixel 4a or newer and flash <a href="https://grapheneos.org/">
     GrapheneOS</a>. GrapheneOS does not contain any tracking unlike the stock OS on most devices. Additionally, GrapheneOS
     retains the baseline security model whilst improving upon it with <a href="https://grapheneos.org/features">substantial
     hardening enhancements</a> — examples of which include a <a href="https://github.com/GrapheneOS/hardened_malloc">hardened


### PR DESCRIPTION
Google Pixel 4 is EoL and should not intentionally be used since GrapheneOS extended support releases are not designed for this purpose, only for users of Pixel 4 who need more time to migrate to a supported device; update minimum model to the oldest supported device, Pixel 4a.