### PR TITLE
Update firefox-chromium.html comparison regarding font restriction in Fireox

### DIFF
--- a/firefox-chromium.html
+++ b/firefox-chromium.html
@@ -426,8 +426,8 @@
     Untrusted fonts have historically been a common source of vulnerabilities within Windows. As such, Windows includes a mitigation to <a
     href="https://docs.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/feature-to-block-untrusted-fonts">block untrusted fonts from specific processes
     to reduce attack surface</a>. <a href="https://github.com/chromium/chromium/commit/441d852dbcb7b9b31328393c7e31562b1e268399">Chromium added support for this in 2016</a>
-    in the form of <code>MITIGATION_NONSYSTEM_FONT_DISABLE</code> and enabled it for most child processes; however, <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1689128">
-    Firefox has yet to enable this in any</a>.
+    in the form of <code>MITIGATION_NONSYSTEM_FONT_DISABLE</code> and enabled it for most child processes; <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1689128">
+    Firefox has enabled this in version 117 in 2023.</a>.
   </p>
 
   <table>

--- a/firefox-chromium.html
+++ b/firefox-chromium.html
@@ -445,7 +445,7 @@
         <tr>
           <td class="identifier-column">Renderer/Content</td>
           <td>Y</td>
-          <td>N</td>
+          <td>Y</td>
         </tr>
         <tr>
           <td class="identifier-column">GPU</td>


### PR DESCRIPTION
The linked bug report here actually states it has been fixed in Firefox in version 117, so I've updated the statement.

https://bugzilla.mozilla.org/show_bug.cgi?id=1689128

I am not sure about the details so feel free to adjust if, but the linked bug is closed, so the statement there certainly needs updating.